### PR TITLE
Move to Snakemake 8

### DIFF
--- a/meta.yml
+++ b/meta.yml
@@ -1,6 +1,6 @@
 package:
   name: pungi
-  version: "0.1.0"
+  version: "0.2.0"
 
 source:
   path: .
@@ -10,9 +10,9 @@ requirements:
     - python
     - pip
   run:
-    - ruamel.yaml=0.17.35
-    - psutil=5.9.5
-    - snakemake=7.*
+    - ruamel.yaml=0.17.*
+    - psutil=5.9.*
+    - snakemake=8.*
 
 build:
   script: pip install .

--- a/pungi/run.py
+++ b/pungi/run.py
@@ -129,7 +129,8 @@ def run_snakemake_workflow(config_path, snake_file_path, output_dir_path, conda_
 
     snakemake_args = ['snakemake', '--snakefile', snake_file_path, '--configfile', config_path, '--directory',
                       output_dir_path, '--conda-prefix', conda_env_dir_path, '--conda-frontend',
-                      'mamba', '--use-conda', '--reason', '--rerun-incomplete', '--printshellcmds']
+                      'mamba', '--software-deployment-method conda', '--reason', '--rerun-incomplete',
+                      '--printshellcmds']
 
     if jobs:
         snakemake_args = snakemake_args + ['--jobs', jobs]

--- a/pungi/run.py
+++ b/pungi/run.py
@@ -129,8 +129,7 @@ def run_snakemake_workflow(config_path, snake_file_path, output_dir_path, conda_
 
     snakemake_args = ['snakemake', '--snakefile', snake_file_path, '--configfile', config_path, '--directory',
                       output_dir_path, '--conda-prefix', conda_env_dir_path, '--conda-frontend',
-                      'mamba', '--software-deployment-method conda', '--reason', '--rerun-incomplete',
-                      '--printshellcmds']
+                      'mamba', '--software-deployment-method conda', '--rerun-incomplete', '--printshellcmds']
 
     if jobs:
         snakemake_args = snakemake_args + ['--jobs', jobs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 dependencies = [
     "ruamel.yaml ~=0.17",
     "psutil ~=5.9",
-    "snakemake ~=8"
+    "snakemake ~=8.0"
 ]
 
 [tool.setuptools.packages]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Pungi"
-version = "0.1.0"
+version = "0.2.0"
 description = """A library for building command-line applications that utilize the Snakemake workflow management system."""
 authors = [
     {name = "Jackson M. Tsuji"},
@@ -13,7 +13,7 @@ readme = "README.md"
 dependencies = [
     "ruamel.yaml ~=0.17",
     "psutil ~=5.9",
-    "snakemake ~=7.32"
+    "snakemake ~=8"
 ]
 
 [tool.setuptools.packages]


### PR DESCRIPTION
This is the code to move to snakemake 8. We initially moved to snakemake 8 much earlier. However, we found a bug in snakemake (Details: https://github.com/snakemake/snakemake/issues/2982) that was causing issues. We need to wait until this bug is addressed before moving forward.